### PR TITLE
Quick fix to calendar auto focus if both dates are not selected when …

### DIFF
--- a/client/src/components/Booking.jsx
+++ b/client/src/components/Booking.jsx
@@ -102,9 +102,13 @@ class Booking extends Component {
   }
 
   onSubmit() {
-    if (!this.state.selectedStartDate || !this.state.selectedStartDate) {
+    if (!this.state.selectedStartDate) {
       this.setState({
         focusedDateInput: 'startDate',
+      });
+    } else if (!this.state.selectedEndDate) {
+      this.setState({
+        focusedDateInput: 'endDate',
       });
     } else {
       this.onSubmitTripDetailsWithDates();


### PR DESCRIPTION
…request booking button is pressed, now autofocuses the start date that is not selected, or start date if neither are selected